### PR TITLE
fix: add API version path to client configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # mcp-server-apache-airflow
+
 [![smithery badge](https://smithery.ai/badge/@yangkyeongmo/mcp-server-apache-airflow)](https://smithery.ai/server/@yangkyeongmo/mcp-server-apache-airflow)
 
 A Model Context Protocol (MCP) server implementation for Apache Airflow, enabling seamless integration with MCP clients. This project provides a standardized way to interact with Apache Airflow through the Model Context Protocol.
@@ -13,87 +14,87 @@ This project implements a [Model Context Protocol](https://modelcontextprotocol.
 
 ## Feature Implementation Status
 
-| Feature | API Path | Status |
-|---------|----------|--------|
-| **DAG Management** | | |
-| List DAGs | `/api/v1/dags` | ✅ |
-| Get DAG Details | `/api/v1/dags/{dag_id}` | ✅ |
-| Pause DAG | `/api/v1/dags/{dag_id}` | ✅ |
-| Unpause DAG | `/api/v1/dags/{dag_id}` | ✅ |
-| Update DAG | `/api/v1/dags/{dag_id}` | ✅ |
-| Delete DAG | `/api/v1/dags/{dag_id}` | ✅ |
-| Get DAG Source | `/api/v1/dagSources/{file_token}` | ✅ |
-| Patch Multiple DAGs | `/api/v1/dags` | ✅ |
-| Reparse DAG File | `/api/v1/dagSources/{file_token}/reparse` | ✅ |
-| **DAG Runs** | | |
-| List DAG Runs | `/api/v1/dags/{dag_id}/dagRuns` | ✅ |
-| Create DAG Run | `/api/v1/dags/{dag_id}/dagRuns` | ✅ |
-| Get DAG Run Details | `/api/v1/dags/{dag_id}/dagRuns/{dag_run_id}` | ✅ |
-| Update DAG Run | `/api/v1/dags/{dag_id}/dagRuns/{dag_run_id}` | ✅ |
-| Delete DAG Run | `/api/v1/dags/{dag_id}/dagRuns/{dag_run_id}` | ✅ |
-| Get DAG Runs Batch | `/api/v1/dags/~/dagRuns/list` | ✅ |
-| Clear DAG Run | `/api/v1/dags/{dag_id}/dagRuns/{dag_run_id}/clear` | ✅ |
-| Set DAG Run Note | `/api/v1/dags/{dag_id}/dagRuns/{dag_run_id}/setNote` | ✅ |
-| Get Upstream Dataset Events | `/api/v1/dags/{dag_id}/dagRuns/{dag_run_id}/upstreamDatasetEvents` | ✅ |
-| **Tasks** | | |
-| List DAG Tasks | `/api/v1/dags/{dag_id}/tasks` | ✅ |
-| Get Task Details | `/api/v1/dags/{dag_id}/tasks/{task_id}` | ✅ |
-| Get Task Instance | `/api/v1/dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances/{task_id}` | ✅ |
-| List Task Instances | `/api/v1/dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances` | ✅ |
-| Update Task Instance | `/api/v1/dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances/{task_id}` | ✅ |
-| Clear Task Instances | `/api/v1/dags/{dag_id}/clearTaskInstances` | ✅ |
-| Set Task Instances State | `/api/v1/dags/{dag_id}/updateTaskInstancesState` | ✅ |
-| **Variables** | | |
-| List Variables | `/api/v1/variables` | ✅ |
-| Create Variable | `/api/v1/variables` | ✅ |
-| Get Variable | `/api/v1/variables/{variable_key}` | ✅ |
-| Update Variable | `/api/v1/variables/{variable_key}` | ✅ |
-| Delete Variable | `/api/v1/variables/{variable_key}` | ✅ |
-| **Connections** | | |
-| List Connections | `/api/v1/connections` | ✅ |
-| Create Connection | `/api/v1/connections` | ✅ |
-| Get Connection | `/api/v1/connections/{connection_id}` | ✅ |
-| Update Connection | `/api/v1/connections/{connection_id}` | ✅ |
-| Delete Connection | `/api/v1/connections/{connection_id}` | ✅ |
-| Test Connection | `/api/v1/connections/test` | ✅ |
-| **Pools** | | |
-| List Pools | `/api/v1/pools` | ✅ |
-| Create Pool | `/api/v1/pools` | ✅ |
-| Get Pool | `/api/v1/pools/{pool_name}` | ✅ |
-| Update Pool | `/api/v1/pools/{pool_name}` | ✅ |
-| Delete Pool | `/api/v1/pools/{pool_name}` | ✅ |
-| **XComs** | | |
-| List XComs | `/api/v1/dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances/{task_id}/xcomEntries` | ✅ |
-| Get XCom Entry | `/api/v1/dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances/{task_id}/xcomEntries/{xcom_key}` | ✅ |
-| **Datasets** | | |
-| List Datasets | `/api/v1/datasets` | ✅ |
-| Get Dataset | `/api/v1/datasets/{uri}` | ✅ |
-| Get Dataset Events | `/api/v1/datasetEvents` | ✅ |
-| Create Dataset Event | `/api/v1/datasetEvents` | ✅ |
-| Get DAG Dataset Queued Event | `/api/v1/dags/{dag_id}/dagRuns/queued/datasetEvents/{uri}` | ✅ |
-| Get DAG Dataset Queued Events | `/api/v1/dags/{dag_id}/dagRuns/queued/datasetEvents` | ✅ |
-| Delete DAG Dataset Queued Event | `/api/v1/dags/{dag_id}/dagRuns/queued/datasetEvents/{uri}` | ✅ |
-| Delete DAG Dataset Queued Events | `/api/v1/dags/{dag_id}/dagRuns/queued/datasetEvents` | ✅ |
-| Get Dataset Queued Events | `/api/v1/datasets/{uri}/dagRuns/queued/datasetEvents` | ✅ |
-| Delete Dataset Queued Events | `/api/v1/datasets/{uri}/dagRuns/queued/datasetEvents` | ✅ |
-| **Monitoring** | | |
-| Get Health | `/api/v1/health` | ✅ |
-| **DAG Stats** | | |
-| Get DAG Stats | `/api/v1/dags/statistics` | ✅ |
-| **Config** | | |
-| Get Config | `/api/v1/config` | ✅ |
-| **Plugins** | | |
-| Get Plugins | `/api/v1/plugins` | ✅ |
-| **Providers** | | |
-| List Providers | `/api/v1/providers` | ✅ |
-| **Event Logs** | | |
-| List Event Logs | `/api/v1/eventLogs` | ✅ |
-| Get Event Log | `/api/v1/eventLogs/{event_log_id}` | ✅ |
-| **System** | | |
-| Get Import Errors | `/api/v1/importErrors` | ✅ |
-| Get Import Error Details | `/api/v1/importErrors/{import_error_id}` | ✅ |
-| Get Health Status | `/api/v1/health` | ✅ |
-| Get Version | `/api/v1/version` | ✅ |
+| Feature                          | API Path                                                                                      | Status |
+| -------------------------------- | --------------------------------------------------------------------------------------------- | ------ |
+| **DAG Management**         |                                                                                               |        |
+| List DAGs                        | `/api/v1/dags`                                                                              | ✅     |
+| Get DAG Details                  | `/api/v1/dags/{dag_id}`                                                                     | ✅     |
+| Pause DAG                        | `/api/v1/dags/{dag_id}`                                                                     | ✅     |
+| Unpause DAG                      | `/api/v1/dags/{dag_id}`                                                                     | ✅     |
+| Update DAG                       | `/api/v1/dags/{dag_id}`                                                                     | ✅     |
+| Delete DAG                       | `/api/v1/dags/{dag_id}`                                                                     | ✅     |
+| Get DAG Source                   | `/api/v1/dagSources/{file_token}`                                                           | ✅     |
+| Patch Multiple DAGs              | `/api/v1/dags`                                                                              | ✅     |
+| Reparse DAG File                 | `/api/v1/dagSources/{file_token}/reparse`                                                   | ✅     |
+| **DAG Runs**               |                                                                                               |        |
+| List DAG Runs                    | `/api/v1/dags/{dag_id}/dagRuns`                                                             | ✅     |
+| Create DAG Run                   | `/api/v1/dags/{dag_id}/dagRuns`                                                             | ✅     |
+| Get DAG Run Details              | `/api/v1/dags/{dag_id}/dagRuns/{dag_run_id}`                                                | ✅     |
+| Update DAG Run                   | `/api/v1/dags/{dag_id}/dagRuns/{dag_run_id}`                                                | ✅     |
+| Delete DAG Run                   | `/api/v1/dags/{dag_id}/dagRuns/{dag_run_id}`                                                | ✅     |
+| Get DAG Runs Batch               | `/api/v1/dags/~/dagRuns/list`                                                               | ✅     |
+| Clear DAG Run                    | `/api/v1/dags/{dag_id}/dagRuns/{dag_run_id}/clear`                                          | ✅     |
+| Set DAG Run Note                 | `/api/v1/dags/{dag_id}/dagRuns/{dag_run_id}/setNote`                                        | ✅     |
+| Get Upstream Dataset Events      | `/api/v1/dags/{dag_id}/dagRuns/{dag_run_id}/upstreamDatasetEvents`                          | ✅     |
+| **Tasks**                  |                                                                                               |        |
+| List DAG Tasks                   | `/api/v1/dags/{dag_id}/tasks`                                                               | ✅     |
+| Get Task Details                 | `/api/v1/dags/{dag_id}/tasks/{task_id}`                                                     | ✅     |
+| Get Task Instance                | `/api/v1/dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances/{task_id}`                        | ✅     |
+| List Task Instances              | `/api/v1/dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances`                                  | ✅     |
+| Update Task Instance             | `/api/v1/dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances/{task_id}`                        | ✅     |
+| Clear Task Instances             | `/api/v1/dags/{dag_id}/clearTaskInstances`                                                  | ✅     |
+| Set Task Instances State         | `/api/v1/dags/{dag_id}/updateTaskInstancesState`                                            | ✅     |
+| **Variables**              |                                                                                               |        |
+| List Variables                   | `/api/v1/variables`                                                                         | ✅     |
+| Create Variable                  | `/api/v1/variables`                                                                         | ✅     |
+| Get Variable                     | `/api/v1/variables/{variable_key}`                                                          | ✅     |
+| Update Variable                  | `/api/v1/variables/{variable_key}`                                                          | ✅     |
+| Delete Variable                  | `/api/v1/variables/{variable_key}`                                                          | ✅     |
+| **Connections**            |                                                                                               |        |
+| List Connections                 | `/api/v1/connections`                                                                       | ✅     |
+| Create Connection                | `/api/v1/connections`                                                                       | ✅     |
+| Get Connection                   | `/api/v1/connections/{connection_id}`                                                       | ✅     |
+| Update Connection                | `/api/v1/connections/{connection_id}`                                                       | ✅     |
+| Delete Connection                | `/api/v1/connections/{connection_id}`                                                       | ✅     |
+| Test Connection                  | `/api/v1/connections/test`                                                                  | ✅     |
+| **Pools**                  |                                                                                               |        |
+| List Pools                       | `/api/v1/pools`                                                                             | ✅     |
+| Create Pool                      | `/api/v1/pools`                                                                             | ✅     |
+| Get Pool                         | `/api/v1/pools/{pool_name}`                                                                 | ✅     |
+| Update Pool                      | `/api/v1/pools/{pool_name}`                                                                 | ✅     |
+| Delete Pool                      | `/api/v1/pools/{pool_name}`                                                                 | ✅     |
+| **XComs**                  |                                                                                               |        |
+| List XComs                       | `/api/v1/dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances/{task_id}/xcomEntries`            | ✅     |
+| Get XCom Entry                   | `/api/v1/dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances/{task_id}/xcomEntries/{xcom_key}` | ✅     |
+| **Datasets**               |                                                                                               |        |
+| List Datasets                    | `/api/v1/datasets`                                                                          | ✅     |
+| Get Dataset                      | `/api/v1/datasets/{uri}`                                                                    | ✅     |
+| Get Dataset Events               | `/api/v1/datasetEvents`                                                                     | ✅     |
+| Create Dataset Event             | `/api/v1/datasetEvents`                                                                     | ✅     |
+| Get DAG Dataset Queued Event     | `/api/v1/dags/{dag_id}/dagRuns/queued/datasetEvents/{uri}`                                  | ✅     |
+| Get DAG Dataset Queued Events    | `/api/v1/dags/{dag_id}/dagRuns/queued/datasetEvents`                                        | ✅     |
+| Delete DAG Dataset Queued Event  | `/api/v1/dags/{dag_id}/dagRuns/queued/datasetEvents/{uri}`                                  | ✅     |
+| Delete DAG Dataset Queued Events | `/api/v1/dags/{dag_id}/dagRuns/queued/datasetEvents`                                        | ✅     |
+| Get Dataset Queued Events        | `/api/v1/datasets/{uri}/dagRuns/queued/datasetEvents`                                       | ✅     |
+| Delete Dataset Queued Events     | `/api/v1/datasets/{uri}/dagRuns/queued/datasetEvents`                                       | ✅     |
+| **Monitoring**             |                                                                                               |        |
+| Get Health                       | `/api/v1/health`                                                                            | ✅     |
+| **DAG Stats**              |                                                                                               |        |
+| Get DAG Stats                    | `/api/v1/dags/statistics`                                                                   | ✅     |
+| **Config**                 |                                                                                               |        |
+| Get Config                       | `/api/v1/config`                                                                            | ✅     |
+| **Plugins**                |                                                                                               |        |
+| Get Plugins                      | `/api/v1/plugins`                                                                           | ✅     |
+| **Providers**              |                                                                                               |        |
+| List Providers                   | `/api/v1/providers`                                                                         | ✅     |
+| **Event Logs**             |                                                                                               |        |
+| List Event Logs                  | `/api/v1/eventLogs`                                                                         | ✅     |
+| Get Event Log                    | `/api/v1/eventLogs/{event_log_id}`                                                          | ✅     |
+| **System**                 |                                                                                               |        |
+| Get Import Errors                | `/api/v1/importErrors`                                                                      | ✅     |
+| Get Import Error Details         | `/api/v1/importErrors/{import_error_id}`                                                    | ✅     |
+| Get Health Status                | `/api/v1/health`                                                                            | ✅     |
+| Get Version                      | `/api/v1/version`                                                                           | ✅     |
 
 ## Setup
 
@@ -104,10 +105,12 @@ This project depends on the official Apache Airflow client library (`apache-airf
 ### Environment Variables
 
 Set the following environment variables:
+
 ```
 AIRFLOW_HOST=<your-airflow-host>
 AIRFLOW_USERNAME=<your-airflow-username>
 AIRFLOW_PASSWORD=<your-airflow-password>
+AIRFLOW_API_VERSION=v1  # Optional, defaults to v1
 ```
 
 ### Usage with Claude Desktop
@@ -186,6 +189,7 @@ Allowed values are:
 ### Manual Execution
 
 You can also run the server manually:
+
 ```bash
 make run
 ```
@@ -193,10 +197,12 @@ make run
 `make run` accepts following options:
 
 Options:
+
 - `--port`: Port to listen on for SSE (default: 8000)
 - `--transport`: Transport type (stdio/sse, default: stdio)
 
 Or, you could run the sse server directly, which accepts same parameters:
+
 ```bash
 make run-sse
 ```

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -19,7 +19,10 @@ startCommand:
       airflowPassword:
         type: string
         description: The password for Airflow authentication.
+      airflowApiVersion:
+        type: string
+        description: The Airflow API version to use (defaults to v1).
   commandFunction:
     # A function that produces the CLI command to start the MCP on stdio.
     |-
-    (config) => ({ command: 'python', args: ['src/server.py'], env: { AIRFLOW_HOST: config.airflowHost, AIRFLOW_USERNAME: config.airflowUsername, AIRFLOW_PASSWORD: config.airflowPassword } })
+    (config) => ({ command: 'python', args: ['src/server.py'], env: { AIRFLOW_HOST: config.airflowHost, AIRFLOW_USERNAME: config.airflowUsername, AIRFLOW_PASSWORD: config.airflowPassword, AIRFLOW_API_VERSION: config.airflowApiVersion || 'v1' } })

--- a/src/airflow/airflow_client.py
+++ b/src/airflow/airflow_client.py
@@ -4,7 +4,7 @@ from src.envs import AIRFLOW_HOST, AIRFLOW_PASSWORD, AIRFLOW_USERNAME
 
 # Create a configuration and API client
 configuration = Configuration(
-    host=AIRFLOW_HOST,
+    host=f"{AIRFLOW_HOST}/api/v1",
     username=AIRFLOW_USERNAME,
     password=AIRFLOW_PASSWORD,
 )

--- a/src/airflow/airflow_client.py
+++ b/src/airflow/airflow_client.py
@@ -1,15 +1,17 @@
+from urllib.parse import urljoin
+
 from airflow_client.client import ApiClient, Configuration
 
 from src.envs import (
+    AIRFLOW_API_VERSION,
     AIRFLOW_HOST,
     AIRFLOW_PASSWORD,
     AIRFLOW_USERNAME,
-    AIRFLOW_API_VERSION,
 )
 
 # Create a configuration and API client
 configuration = Configuration(
-    host=f"{AIRFLOW_HOST}/api/{AIRFLOW_API_VERSION}",
+    host=urljoin(AIRFLOW_HOST, f"/api/{AIRFLOW_API_VERSION}"),
     username=AIRFLOW_USERNAME,
     password=AIRFLOW_PASSWORD,
 )

--- a/src/airflow/airflow_client.py
+++ b/src/airflow/airflow_client.py
@@ -1,10 +1,15 @@
 from airflow_client.client import ApiClient, Configuration
 
-from src.envs import AIRFLOW_HOST, AIRFLOW_PASSWORD, AIRFLOW_USERNAME
+from src.envs import (
+    AIRFLOW_HOST,
+    AIRFLOW_PASSWORD,
+    AIRFLOW_USERNAME,
+    AIRFLOW_API_VERSION,
+)
 
 # Create a configuration and API client
 configuration = Configuration(
-    host=f"{AIRFLOW_HOST}/api/v1",
+    host=f"{AIRFLOW_HOST}/api/{AIRFLOW_API_VERSION}",
     username=AIRFLOW_USERNAME,
     password=AIRFLOW_PASSWORD,
 )

--- a/src/envs.py
+++ b/src/envs.py
@@ -1,6 +1,7 @@
 import os
+from urllib.parse import urlparse
 
-AIRFLOW_HOST = os.getenv("AIRFLOW_HOST").rstrip("/")
+AIRFLOW_HOST = urlparse(os.getenv("AIRFLOW_HOST"))._replace(path="").geturl().rstrip("/")
 AIRFLOW_USERNAME = os.getenv("AIRFLOW_USERNAME")
 AIRFLOW_PASSWORD = os.getenv("AIRFLOW_PASSWORD")
 AIRFLOW_API_VERSION = os.getenv("AIRFLOW_API_VERSION", "v1")

--- a/src/envs.py
+++ b/src/envs.py
@@ -3,3 +3,4 @@ import os
 AIRFLOW_HOST = os.getenv("AIRFLOW_HOST").rstrip("/")
 AIRFLOW_USERNAME = os.getenv("AIRFLOW_USERNAME")
 AIRFLOW_PASSWORD = os.getenv("AIRFLOW_PASSWORD")
+AIRFLOW_API_VERSION = os.getenv("AIRFLOW_API_VERSION", "v1")


### PR DESCRIPTION
Adds support for configurable Airflow API versions through environment
variables, preparing for future API version changes.

- Added AIRFLOW_API_VERSION environment variable (defaults to v1)
- Updated client configuration to use the version variable
- Updated documentation and Smithery config
- Maintains backward compatibility with existing setups

This change allows easier migration to future Airflow API versions
without requiring code changes.

#### Update:
Used urlparse and urljoin to properly handle API URL construction,
ensuring consistent behavior regardless of whether AIRFLOW_HOST
includes /api/v1 or not. This maintains backward compatibility
while making the URL handling more robust.

- Strip path component from AIRFLOW_HOST using urlparse
- Use urljoin to properly construct API endpoint URL
- Maintain backward compatibility for existing configurations