### PR TITLE
Fix the issue in creating dag run

### DIFF
--- a/src/airflow/dagrun.py
+++ b/src/airflow/dagrun.py
@@ -48,7 +48,6 @@ async def post_dag_run(
     # state: Optional[str] = None,  # TODO: add state
 ) -> List[Union[types.TextContent, types.ImageContent, types.EmbeddedResource]]:
     dag_run = DAGRun(
-        dag_id=dag_id,
         dag_run_id=dag_run_id,
         data_interval_end=data_interval_end,
         data_interval_start=data_interval_start,


### PR DESCRIPTION
Airflow api has removed dag_id to be passed inside dagrun object. This is creating issues when post_dag_run call is made via LLM. https://github.com/apache/airflow-client-python/issues/75