### PR TITLE
Add read only env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ AIRFLOW_HOST=<your-airflow-host>        # Optional, defaults to http://localhost
 AIRFLOW_USERNAME=<your-airflow-username>
 AIRFLOW_PASSWORD=<your-airflow-password>
 AIRFLOW_API_VERSION=v1                  # Optional, defaults to v1
+READ_ONLY=true                          # Optional, enables read-only mode (true/false, defaults to false)
 ```
 
 ### Usage with Claude Desktop
@@ -144,11 +145,12 @@ For read-only mode (recommended for safety):
   "mcpServers": {
     "mcp-server-apache-airflow": {
       "command": "uvx",
-      "args": ["mcp-server-apache-airflow", "--read-only"],
+      "args": ["mcp-server-apache-airflow"],
       "env": {
         "AIRFLOW_HOST": "https://your-airflow-host",
         "AIRFLOW_USERNAME": "your-username",
-        "AIRFLOW_PASSWORD": "your-password"
+        "AIRFLOW_PASSWORD": "your-password",
+        "READ_ONLY": "true"
       }
     }
   }
@@ -210,10 +212,16 @@ Allowed values are:
 
 ### Read-Only Mode
 
-You can run the server in read-only mode by using the `--read-only` flag. This will only expose tools that perform read operations (GET requests) and exclude any tools that create, update, or delete resources.
+You can run the server in read-only mode by using the `--read-only` flag or by setting the `READ_ONLY=true` environment variable. This will only expose tools that perform read operations (GET requests) and exclude any tools that create, update, or delete resources.
 
+Using the command-line flag:
 ```bash
 uv run mcp-server-apache-airflow --read-only
+```
+
+Using the environment variable:
+```bash
+READ_ONLY=true uv run mcp-server-apache-airflow
 ```
 
 In read-only mode, the server will only expose tools like:

--- a/src/envs.py
+++ b/src/envs.py
@@ -9,3 +9,6 @@ AIRFLOW_HOST = urlparse(_airflow_host_raw)._replace(path="").geturl().rstrip("/"
 AIRFLOW_USERNAME = os.getenv("AIRFLOW_USERNAME")
 AIRFLOW_PASSWORD = os.getenv("AIRFLOW_PASSWORD")
 AIRFLOW_API_VERSION = os.getenv("AIRFLOW_API_VERSION", "v1")
+
+# Environment variable for read-only mode
+READ_ONLY = os.getenv("READ_ONLY", "false").lower() in ("true", "1", "yes", "on")

--- a/src/main.py
+++ b/src/main.py
@@ -19,6 +19,7 @@ from src.airflow.taskinstance import get_all_functions as get_taskinstance_funct
 from src.airflow.variable import get_all_functions as get_variable_functions
 from src.airflow.xcom import get_all_functions as get_xcom_functions
 from src.enums import APIType
+from src.envs import READ_ONLY
 
 APITYPE_TO_FUNCTIONS = {
     APIType.CONFIG: get_config_functions,
@@ -73,6 +74,7 @@ def filter_functions_for_read_only(functions: list[tuple]) -> list[tuple]:
 @click.option(
     "--read-only",
     is_flag=True,
+    default=READ_ONLY,
     help="Only expose read-only tools (GET operations, no CREATE/UPDATE/DELETE)",
 )
 def main(transport: str, mcp_host: str, mcp_port: int, apis: list[str], read_only: bool) -> None:


### PR DESCRIPTION
Add `READ_ONLY` environment variable to configure read-only mode, improving deployment flexibility and Claude Desktop integration.

---
[Slack Thread](https://ohou-se.slack.com/archives/D09243RGPL6/p1760684452511069?thread_ts=1760684452.511069&cid=D09243RGPL6)

<a href="https://cursor.com/background-agent?bcId=bc-ace0d513-8bc8-4419-af8a-869661a15697"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ace0d513-8bc8-4419-af8a-869661a15697"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

