### PR TITLE
Fix AIRFLOW_HOST truncation

### DIFF
--- a/src/airflow/airflow_client.py
+++ b/src/airflow/airflow_client.py
@@ -1,5 +1,3 @@
-from urllib.parse import urljoin
-
 from airflow_client.client import ApiClient, Configuration
 
 from src.envs import (
@@ -12,7 +10,7 @@ from src.envs import (
 
 # Create a configuration and API client
 configuration = Configuration(
-    host=urljoin(AIRFLOW_HOST, f"/api/{AIRFLOW_API_VERSION}"),
+    host=f"{AIRFLOW_HOST}/api/{AIRFLOW_API_VERSION}",
 )
 
 # Set up authentication - prefer JWT token if available, fallback to basic auth

--- a/src/envs.py
+++ b/src/envs.py
@@ -1,10 +1,8 @@
 import os
-from urllib.parse import urlparse
 
 # Environment variables for Airflow connection
 # AIRFLOW_HOST defaults to localhost for development/testing if not provided
-_airflow_host_raw = os.getenv("AIRFLOW_HOST", "http://localhost:8080")
-AIRFLOW_HOST = urlparse(_airflow_host_raw)._replace(path="").geturl().rstrip("/")
+AIRFLOW_HOST = os.getenv("AIRFLOW_HOST", "http://localhost:8080").rstrip("/")
 
 # Authentication - supports both basic auth and JWT token auth
 AIRFLOW_USERNAME = os.getenv("AIRFLOW_USERNAME")

--- a/test/test_airflow_client.py
+++ b/test/test_airflow_client.py
@@ -137,11 +137,11 @@ class TestAirflowClientAuthentication:
             from src.envs import AIRFLOW_API_VERSION, AIRFLOW_HOST, AIRFLOW_JWT_TOKEN
 
             # Verify environment variables are parsed correctly
-            assert AIRFLOW_HOST == "https://airflow.example.com:8080"
+            assert AIRFLOW_HOST == "https://airflow.example.com:8080/custom"
             assert AIRFLOW_JWT_TOKEN == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9..."
             assert AIRFLOW_API_VERSION == "v2"
 
             # Verify configuration uses parsed values
-            assert configuration.host == "https://airflow.example.com:8080/api/v2"
+            assert configuration.host == "https://airflow.example.com:8080/custom/api/v2"
             assert configuration.api_key == {"Authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9..."}
             assert configuration.api_key_prefix == {"Authorization": ""}


### PR DESCRIPTION
# Overview
Currently, `AIRFLOW_HOST` is truncated if it contains a path. If an airflow environment is hosted anywhere other than the base url, this is problematic.

# Reproduction

## Before Changes
```
cd mcp-server-apache-airflow                                                                                                
python3 -c "
import os
os.environ['AIRFLOW_HOST'] = 'https://airflow.company.com/production'
import sys
sys.path.insert(0, 'src')
from envs import AIRFLOW_HOST
print(f'Input:  {os.environ[\"AIRFLOW_HOST\"]}')
print(f'Output: {AIRFLOW_HOST}')
"
Input:  https://airflow.company.com/production
Output: https://airflow.company.com                        <---- This is the problem
```

## After Changes
```
 cd mcp-server-apache-airflow
python3 -c "
import os
os.environ['AIRFLOW_HOST'] = 'https://airflow.company.com/production'
import sys
sys.path.insert(0, 'src')
from envs import AIRFLOW_HOST
print(f'Input:  {os.environ[\"AIRFLOW_HOST\"]}')
print(f'Output: {AIRFLOW_HOST}')
"
Input:  https://airflow.company.com/production
Output: https://airflow.company.com/production
```