### PR TITLE
feat: Add health check API for MCP Server health monitoring

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-server-apache-airflow"
-version = "0.2.10"
+version = "0.2.11"
 description = "Model Context Protocol (MCP) server for Apache Airflow"
 authors = [
     { name = "Gyeongmo Yang", email = "me@yanggyeongmo.com" }

--- a/src/routes.py
+++ b/src/routes.py
@@ -6,5 +6,5 @@ def register_routes(app):
     @app.custom_route("/health", methods=["GET"])
     async def health_check(request: Request) -> JSONResponse:
         return JSONResponse({"status": "ok"})
-    return health_check
 
+    return health_check

--- a/src/routes.py
+++ b/src/routes.py
@@ -1,0 +1,10 @@
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+
+def register_routes(app):
+    @app.custom_route("/health", methods=["GET"])
+    async def health_check(request: Request) -> JSONResponse:
+        return JSONResponse({"status": "ok"})
+    return health_check
+

--- a/src/server.py
+++ b/src/server.py
@@ -1,10 +1,7 @@
 from fastmcp import FastMCP
-from starlette.requests import Request
-from starlette.responses import JSONResponse
+
+from src.routes import register_routes
 
 app = FastMCP("mcp-apache-airflow")
 
-
-@app.custom_route("/health", methods=["GET"])
-async def health_check(request: Request) -> JSONResponse:
-    return JSONResponse({"status": "ok"})
+register_routes(app)

--- a/src/server.py
+++ b/src/server.py
@@ -1,3 +1,10 @@
 from fastmcp import FastMCP
+from starlette.requests import Request
+from starlette.responses import JSONResponse
 
 app = FastMCP("mcp-apache-airflow")
+
+
+@app.custom_route("/health", methods=["GET"])
+async def health_check(request: Request) -> JSONResponse:
+    return JSONResponse({"status": "ok"})

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -23,23 +23,6 @@ class TestHealthCheckRoute:
         health_route = next(r for r in app._additional_http_routes if r.path == "/health")
         assert "GET" in health_route.methods
 
-    @pytest.mark.asyncio
-    async def test_health_check_returns_ok_status(self):
-        """Test that the health_check function returns status ok."""
-        from src.server import health_check
-
-        response = await health_check(request=None)
-        assert response.status_code == 200
-
-    @pytest.mark.asyncio
-    async def test_health_check_response_body(self):
-        """Test that the health_check response body contains status ok."""
-        from src.server import health_check
-
-        response = await health_check(request=None)
-        body = json.loads(response.body)
-        assert body == {"status": "ok"}
-
     def test_health_endpoint_via_http_client(self):
         """Test the /health endpoint returns 200 via HTTP test client."""
         from src.server import app

--- a/test/test_routes.py
+++ b/test/test_routes.py
@@ -1,0 +1,50 @@
+"""Tests for custom HTTP routes using pytest framework."""
+
+import json
+
+import pytest
+from starlette.testclient import TestClient
+
+
+class TestHealthCheckRoute:
+    """Test cases for the /health custom route."""
+
+    def test_health_route_is_registered(self):
+        """Test that the /health route is registered in the app."""
+        from src.server import app
+
+        paths = [route.path for route in app._additional_http_routes]
+        assert "/health" in paths
+
+    def test_health_route_methods(self):
+        """Test that the /health route accepts GET requests."""
+        from src.server import app
+
+        health_route = next(r for r in app._additional_http_routes if r.path == "/health")
+        assert "GET" in health_route.methods
+
+    @pytest.mark.asyncio
+    async def test_health_check_returns_ok_status(self):
+        """Test that the health_check function returns status ok."""
+        from src.server import health_check
+
+        response = await health_check(request=None)
+        assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_health_check_response_body(self):
+        """Test that the health_check response body contains status ok."""
+        from src.server import health_check
+
+        response = await health_check(request=None)
+        body = json.loads(response.body)
+        assert body == {"status": "ok"}
+
+    def test_health_endpoint_via_http_client(self):
+        """Test the /health endpoint returns 200 via HTTP test client."""
+        from src.server import app
+
+        client = TestClient(app.http_app())
+        response = client.get("/health")
+        assert response.status_code == 200
+        assert response.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary                                                
Add a custom HTTP `/health` endpoint to the FastMCP server for health check monitoring. This endpoint enables load balancers, Kubernetes probes, and monitoring tools to verify that the MCP server is running and healthy.

## Testing Results
All unit tests pass
<img width="1088" height="235" alt="image" src="https://github.com/user-attachments/assets/9acfd3d3-81be-46c1-b822-2a79ba22ec5e" />

<br>

MCP Server running successfully
<img width="1088" height="464" alt="image" src="https://github.com/user-attachments/assets/61022e6e-f5a0-4cfb-87f3-d74f9c4f2685" />

<br>

Health check API working as expected
<img width="1264" height="155" alt="image" src="https://github.com/user-attachments/assets/d8fc59a5-9388-4f89-8c26-ca39c438af5d" />

