### PR TITLE
Fix: Airflow 3 API /v2/ compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-server-apache-airflow"
-version = "0.2.10"
+version = "0.2.11"
 description = "Model Context Protocol (MCP) server for Apache Airflow"
 authors = [
     { name = "Gyeongmo Yang", email = "me@yanggyeongmo.com" }

--- a/src/envs.py
+++ b/src/envs.py
@@ -1,8 +1,9 @@
 import os
 from urllib.parse import urlparse
 
+import requests
+
 # Environment variables for Airflow connection
-# AIRFLOW_HOST defaults to localhost for development/testing if not provided
 _airflow_host_raw = os.getenv("AIRFLOW_HOST", "http://localhost:8080")
 AIRFLOW_HOST = urlparse(_airflow_host_raw)._replace(path="").geturl().rstrip("/")
 
@@ -10,7 +11,44 @@ AIRFLOW_HOST = urlparse(_airflow_host_raw)._replace(path="").geturl().rstrip("/"
 AIRFLOW_USERNAME = os.getenv("AIRFLOW_USERNAME")
 AIRFLOW_PASSWORD = os.getenv("AIRFLOW_PASSWORD")
 AIRFLOW_JWT_TOKEN = os.getenv("AIRFLOW_JWT_TOKEN")
-AIRFLOW_API_VERSION = os.getenv("AIRFLOW_API_VERSION", "v1")
 
 # Environment variable for read-only mode
 READ_ONLY = os.getenv("READ_ONLY", "false").lower() in ("true", "1", "yes", "on")
+
+# -----------------------------
+# Auto-detect Airflow API version
+# -----------------------------
+
+
+def detect_api_version():
+    headers = {}
+
+    if AIRFLOW_JWT_TOKEN:
+        headers["Authorization"] = f"Bearer {AIRFLOW_JWT_TOKEN}"
+
+    auth = None
+    if AIRFLOW_USERNAME and AIRFLOW_PASSWORD:
+        auth = (AIRFLOW_USERNAME, AIRFLOW_PASSWORD)
+
+    for version in ["v2", "v1"]:  # Try v2 first (Airflow 3)
+        try:
+            response = requests.get(
+                f"{AIRFLOW_HOST}/api/{version}/version",
+                headers=headers,
+                auth=auth,
+                timeout=3,
+            )
+            if response.status_code == 200:
+                return version
+        except requests.RequestException:
+            pass
+
+    # Default fallback
+    return "v1"
+
+
+# If user explicitly sets version, respect it
+AIRFLOW_API_VERSION = os.getenv("AIRFLOW_API_VERSION")
+
+if not AIRFLOW_API_VERSION:
+    AIRFLOW_API_VERSION = detect_api_version()

--- a/uv.lock
+++ b/uv.lock
@@ -750,7 +750,7 @@ wheels = [
 
 [[package]]
 name = "mcp-server-apache-airflow"
-version = "0.2.9"
+version = "0.2.10"
 source = { editable = "." }
 dependencies = [
     { name = "apache-airflow-client" },


### PR DESCRIPTION
The current envs file in src only use airflow API call for v1 but for airflow version 3 we need API call with v2 (https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html)

Working:
The AIRFLOW_API_VERSION will get the value from function detect_api_version() which will verify which airflow verison the user is using if it is using airflow version less than 3 which means the API call should use v1 and if it is using airflow version3 it will use API call as v2.
This discussion is happing on the basics of curl result it will send the request for both v1 and v2 API call to {AIRFLOW_HOST}/api/{version}/version and according to 200 it will choose the API version.

Testing:
I have test on airflow version 3.1.4 and it worked as expected.