### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ This project implements a [Model Context Protocol](https://modelcontextprotocol.
 | Get Health Status                | `/api/v1/health`                                                                            | ✅     |
 | Get Version                      | `/api/v1/version`                                                                           | ✅     |
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/yangkyeongmo-mcp-server-apache-airflow).
+
 ## Setup
 
 ### Dependencies


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/yangkyeongmo-mcp-server-apache-airflow)