### PR TITLE
fix: preserve URL path prefix in AIRFLOW_HOST

### DIFF
--- a/src/airflow/airflow_client.py
+++ b/src/airflow/airflow_client.py
@@ -1,5 +1,3 @@
-from urllib.parse import urljoin
-
 from airflow_client.client import ApiClient, Configuration
 
 from src.envs import (
@@ -12,7 +10,7 @@ from src.envs import (
 
 # Create a configuration and API client
 configuration = Configuration(
-    host=urljoin(AIRFLOW_HOST, f"/api/{AIRFLOW_API_VERSION}"),
+    host=f"{AIRFLOW_HOST}/api/{AIRFLOW_API_VERSION}",
 )
 
 # Set up authentication - prefer JWT token if available, fallback to basic auth

--- a/src/envs.py
+++ b/src/envs.py
@@ -1,10 +1,12 @@
 import os
-from urllib.parse import urlparse
+import re
 
 # Environment variables for Airflow connection
 # AIRFLOW_HOST defaults to localhost for development/testing if not provided
 _airflow_host_raw = os.getenv("AIRFLOW_HOST", "http://localhost:8080")
-AIRFLOW_HOST = urlparse(_airflow_host_raw)._replace(path="").geturl().rstrip("/")
+# Strip trailing slashes, then strip an accidental /api/vN suffix so we don't
+# end up with /api/vN/api/vN when the API URL is constructed later.
+AIRFLOW_HOST = re.sub(r"/api/v\d+$", "", _airflow_host_raw.rstrip("/"))
 
 # Authentication - supports both basic auth and JWT token auth
 AIRFLOW_USERNAME = os.getenv("AIRFLOW_USERNAME")

--- a/test/test_airflow_client.py
+++ b/test/test_airflow_client.py
@@ -5,6 +5,7 @@ import os
 import sys
 from unittest.mock import patch
 
+import pytest
 from airflow_client.client import ApiClient
 
 
@@ -155,12 +156,99 @@ class TestAirflowClientAuthentication:
             from src.envs import AIRFLOW_API_VERSION, AIRFLOW_HOST, AIRFLOW_JWT_TOKEN
 
             # Verify environment variables are parsed correctly
-            assert AIRFLOW_HOST == "https://airflow.example.com:8080"
+            assert AIRFLOW_HOST == "https://airflow.example.com:8080/custom"
             assert AIRFLOW_JWT_TOKEN == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9..."
             assert AIRFLOW_API_VERSION == "v2"
 
             # Verify configuration uses parsed values
-            assert configuration.host == "https://airflow.example.com:8080/api/v2"
+            assert configuration.host == "https://airflow.example.com:8080/custom/api/v2"
             assert configuration.api_key == {"Authorization": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9..."}
             assert configuration.api_key_prefix == {"Authorization": "Bearer"}
             assert api_client.default_headers["Authorization"] == "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9..."
+
+    @pytest.mark.parametrize(
+        "airflow_host, api_version, expected_host, expected_api_url",
+        [
+            ("https://airflow.example.com", "v1", "https://airflow.example.com", "https://airflow.example.com/api/v1"),
+            (
+                "https://airflow.example.com:8080",
+                "v1",
+                "https://airflow.example.com:8080",
+                "https://airflow.example.com:8080/api/v1",
+            ),
+            (
+                "https://airflow.example.com/my-prefix",
+                "v1",
+                "https://airflow.example.com/my-prefix",
+                "https://airflow.example.com/my-prefix/api/v1",
+            ),
+            (
+                "https://airflow.example.com/my-prefix/",
+                "v1",
+                "https://airflow.example.com/my-prefix",
+                "https://airflow.example.com/my-prefix/api/v1",
+            ),
+            (
+                "https://platform.example.com/org/team/airflow",
+                "v1",
+                "https://platform.example.com/org/team/airflow",
+                "https://platform.example.com/org/team/airflow/api/v1",
+            ),
+            (
+                "https://airflow.example.com/prefix///",
+                "v1",
+                "https://airflow.example.com/prefix",
+                "https://airflow.example.com/prefix/api/v1",
+            ),
+            (
+                "https://airflow.example.com/api/v1",
+                "v1",
+                "https://airflow.example.com",
+                "https://airflow.example.com/api/v1",
+            ),
+            (
+                "https://airflow.example.com:8080/api/v2",
+                "v2",
+                "https://airflow.example.com:8080",
+                "https://airflow.example.com:8080/api/v2",
+            ),
+            (
+                "https://airflow.example.com/my-prefix/api/v1",
+                "v1",
+                "https://airflow.example.com/my-prefix",
+                "https://airflow.example.com/my-prefix/api/v1",
+            ),
+        ],
+        ids=[
+            "https-no-path",
+            "https-with-port",
+            "single-path-prefix",
+            "trailing-slash",
+            "multi-level-path",
+            "multiple-trailing-slashes",
+            "accidental-api-v1-suffix",
+            "accidental-api-v2-with-port",
+            "path-prefix-plus-accidental-api-v1",
+        ],
+    )
+    def test_airflow_host_url_handling(self, airflow_host, api_version, expected_host, expected_api_url):
+        """Test that AIRFLOW_HOST is preserved and the API URL is built correctly."""
+        with patch.dict(
+            os.environ,
+            {
+                "AIRFLOW_HOST": airflow_host,
+                "AIRFLOW_JWT_TOKEN": "tok",
+                "AIRFLOW_API_VERSION": api_version,
+            },
+            clear=True,
+        ):
+            modules_to_clear = ["src.envs", "src.airflow.airflow_client"]
+            for module in modules_to_clear:
+                if module in sys.modules:
+                    del sys.modules[module]
+
+            from src.airflow.airflow_client import configuration
+            from src.envs import AIRFLOW_HOST
+
+            assert AIRFLOW_HOST == expected_host
+            assert configuration.host == expected_api_url


### PR DESCRIPTION
## Problem

`AIRFLOW_HOST` with a URL path prefix, e.g. `https://airflow.example.com/my-prefix`, results in 404 errors because the path is silently stripped (the `my-prefix` portion is stripped).

This affects Airflow deployments served behind a reverse proxy at a sub-path.

### Root cause

Commit [`5338f94`](https://github.com/yangkyeongmo/mcp-server-apache-airflow/pull/8) ("fix: normalize Airflow API URL construction") introduced `urlparse(...)._replace(path="")` in `src/envs.py` and `urljoin()` in `src/airflow/airflow_client.py` to prevent double `/api/v1/api/v1` when users accidentally include `/api/v1` in `AIRFLOW_HOST`. However, this approach strips **all** path components, breaking legitimate path-prefixed deployments (e.g. Airflow behind a reverse proxy at `/my-prefix`).

1. **`src/envs.py`** — `urlparse(...)._replace(path="")` explicitly removes the entire path component, including valid prefixes.
2. **`src/airflow/airflow_client.py`** — `urljoin(AIRFLOW_HOST, "/api/v1")` discards the base path per [RFC 3986](https://www.rfc-editor.org/rfc/rfc3986#section-5.3) due to the leading `/`.

## Fix

- **`src/envs.py`**: Replace `urlparse` path stripping with `rstrip("/")` + `re.sub(r"/api/v\d+$", ...)` — this preserves the full URL path while still stripping an accidental trailing `/api/vN` suffix to maintain backward compatibility with PR #8.
- **`src/airflow/airflow_client.py`**: Replace `urljoin()` with an f-string (`f"{AIRFLOW_HOST}/api/{AIRFLOW_API_VERSION}"`) so the path prefix is always preserved.

Hosts without a path prefix are unaffected.

## Test plan

Tests were written **before** the fix was applied to confirm the bug, then re-run after to confirm the fix.

Tests added against unmodified source — observed failures. With the original `envs.py` (`urlparse` path stripping) and `airflow_client.py` (`urljoin`), the new tests correctly fail for every case involving a URL path. Fix applied — all tests pass.